### PR TITLE
runner: allow passing a deferred to get notified of its completion

### DIFF
--- a/src/ablauf/job/manifold.clj
+++ b/src/ablauf/job/manifold.clj
@@ -17,7 +17,6 @@
   "
   (:require [ablauf.job           :as job]
             [ablauf.job.store     :as store]
-            [ablauf.job.ast       :as ast]
             [manifold.deferred    :as d]
             [manifold.stream      :as s]
             [spootnik.transducers :refer [reductions-with]]))
@@ -73,12 +72,19 @@
 
 (defn redispatcher
   "Once dispatchs have been determined by `job/restart`, dispatch
-   actions with callbacks into the restarter."
-  [dispatcher input store id result]
+   actions with callbacks into the restarter.
+   `persist-deferred` is a user-supplied deferred that will be resolved/error'd to signal persist is done"
+  [dispatcher input store id result persist-deferred]
   (fn [[job context dispatchs]]
-    (let [clock (or (get-in context [:exec/runtime :runtime/clock]) timestamp)
+    (let [clock          (or (get-in context [:exec/runtime :runtime/clock]) timestamp)
           ;; Persist to given store, either we get a deferred or nil, doesn't matter
           persist-result (d/->deferred (store/persist store id (dissoc context :exec/runtime) job) nil)]
+
+      ;; callback with persist result
+      (when persist-deferred
+        (-> (d/chain persist-result
+                     #(d/success! persist-deferred %))
+            (d/catch #(d/error! persist-deferred %))))
 
       ;; Launch all dispatchs found
       (doseq [d    dispatchs
@@ -108,14 +114,14 @@
 (defn runner
   "Create a stream which listens for input results and figures
    out next dispatchs to send"
-  [store ast {:keys [action-fn id context buffer runtime] :or {buffer 10}}]
+  [store ast {:keys [action-fn id context buffer runtime persist-deferred] :or {buffer 10}}]
   (let [context    (assoc context :exec/runtime runtime)
         job        (job/make-with-context ast context)
         input      (s/stream buffer (restart-transducer job))
         id         (or id (java.util.UUID/randomUUID))
         result     (d/deferred)
         dispatcher (or action-fn dispatch-action)]
-    (s/consume (redispatcher dispatcher input store id result) input)
+    (s/consume (redispatcher dispatcher input store id result persist-deferred) input)
 
     ;; Put an initial empty result payload in the stream
     ;; to guarantee initial dispatchs are sent

--- a/test/ablauf/job/manifold_test.clj
+++ b/test/ablauf/job/manifold_test.clj
@@ -1,7 +1,5 @@
 (ns ablauf.job.manifold-test
-  (:require [manifold.stream :as stream]
-            [manifold.deferred :as d]
-            [ablauf.job :as job]
+  (:require [manifold.deferred :as d]
             [ablauf.job.ast :as ast]
             [ablauf.job.store :as store]
             [ablauf.job.manifold :refer [runner]]
@@ -13,7 +11,6 @@
       (if fail?
         (d/error-deferred (ex-info "Forced fail" params))
         (d/success-deferred :ok)))))
-
 
 (deftest persist-impacts-execution
   (let [action-fn (fn [{:ast/keys [action payload]}]
@@ -29,6 +26,20 @@
 
     (testing "When persist returns a failed deferred execution is halted"
       (is (thrown? Exception
-            @(runner (mock-store {:fail? true}) ast {:action-fn action-fn}))))))
+            @(runner (mock-store {:fail? true}) ast {:action-fn action-fn}))))
+
+    (testing "on-persist callback gets called with deferred"
+      (let [persisted (d/deferred)
+            _         @(runner (mock-store {:fail? false}) ast {:action-fn action-fn :persist-deferred persisted})]
+        @(-> (d/chain persisted (fn [r] (is (= :ok r))))
+             (d/catch (fn [_] (is (nil? "should never reach this point")))))))
+
+    (testing "on-persist callback gets called even with error"
+      (let [persisted (d/deferred)
+            _         (runner (mock-store {:fail? true}) ast {:action-fn action-fn :persist-deferred persisted})]
+        @(-> (d/chain persisted (fn [_] (assert nil? "should never reach this point")))
+             (d/catch (fn [err] (is (= "Forced fail" (ex-message err))))))))))
 
 
+(comment
+  (run-tests *ns*))


### PR DESCRIPTION
By passing a `persist-deferred` when calling, callers can be notified of the persist operation completion/failure:

```
(let [persisted (d/deferred)
        result      (runner store ast {:action-fn action-fn :persist-deferred persisted})]

  (-> (d/chain persisted (fn [_] {:status 200}))
        (d/catch (fn [err] {:status 500})))))))
```

This is WIP, I'm not too excited with this change but it is necessary.