### PR TITLE
Add a status function for jobs

### DIFF
--- a/src/ablauf/job.clj
+++ b/src/ablauf/job.clj
@@ -171,3 +171,13 @@
   "Predicate to test for pending completion of a (sub)job"
   [job]
   (node/pending? (zip/node job)))
+
+(defn status
+  "Get the job status from an ast"
+  [ast]
+  (cond
+    (pending? ast) :job/pending
+    (failed? ast) :job/failure
+    (done? ast) :job/success
+    :else (throw (ex-info "Wrong AST job state"
+                          {}))))

--- a/test/ablauf/job_test.clj
+++ b/test/ablauf/job_test.clj
@@ -61,3 +61,14 @@
           {:a :a} ;; context updated
           nil ;; no new dispatchs, we're done
           ])))
+
+(deftest status-test
+  (is (= :job/pending
+         (status [{:ast/type :ast/seq, :ast/nodes [{:ast/type :ast/leaf
+                                                    :exec/result :result/pending}]}])))
+  (is (= :job/failure
+         (status [{:ast/type :ast/seq, :ast/nodes [{:ast/type :ast/leaf
+                                                    :exec/result :result/failure}]}])))
+  (is (= :job/success
+         (status [{:ast/type :ast/seq, :ast/nodes [{:ast/type :ast/leaf
+                                                    :exec/result :result/success}]}]))))


### PR DESCRIPTION
This function takes an ast and returns a job status (as a keyword)
depending of the ast state.