### PR TITLE
ablauf.job.manifold: prevent store failure from blocking execution

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -13,5 +13,6 @@
   :deploy-repositories [["snapshots" :clojars]
                         ["releases"  :clojars]]
   :aliases {"kaocha" ["with-profile" "+dev" "run" "-m" "kaocha.runner"]}
-  :profiles {:dev {:dependencies [[lambdaisland/kaocha "0.0-529"]]}}
+  :profiles {:dev {:dependencies [[lambdaisland/kaocha "0.0-529"]]
+                   :pedantic? :ignore}}
   :pedantic? :abort)

--- a/src/ablauf/job/manifold.clj
+++ b/src/ablauf/job/manifold.clj
@@ -17,7 +17,6 @@
   "
   (:require [ablauf.job           :as job]
             [ablauf.job.store     :as store]
-            [ablauf.job.ast       :as ast]
             [manifold.deferred    :as d]
             [manifold.stream      :as s]
             [spootnik.transducers :refer [reductions-with]]))
@@ -77,8 +76,11 @@
   [dispatcher input store id result]
   (fn [[job context dispatchs]]
     (let [clock (or (get-in context [:exec/runtime :runtime/clock]) timestamp)
-          ;; Persist to given store, either we get a deferred or nil, doesn't matter
-          persist-result (d/->deferred (store/persist store id (dissoc context :exec/runtime) job) nil)]
+          ;; Persist to given store, either we get a deferred or nil,
+          ;; doesn't matter
+          persist-result (store/safe-persist store id
+                                             (dissoc context :exec/runtime)
+                                             job)]
 
       ;; Launch all dispatchs found
       (doseq [d    dispatchs


### PR DESCRIPTION
We already ensure that the result that ablauf.job.store yields is
correctly coerced into a deferred to allow it to be chained to
the dispatch execution.

This patch ensures that the call to `store/persist` does the same,
yielding an error-deferred when exceptions are thrown.

The `safe-persist` function is introduced in ablauf.job.store to
isolate this handling.