### PR TITLE
force a first persist call and fix finally node dispatch finding

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -1,0 +1,13 @@
+name: Clojure CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Lint and test
+      run: lein with-profile test do cljfmt check, difftest

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ pom.xml.asc
 /.nrepl-port
 .hgignore
 .hg/
+/.cpcache

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 ablauf: long-running workflow management
 ========================================
 
+[![cljdoc badge](https://cljdoc.xyz/badge/exoscale/ablauf)](https://cljdoc.org/d/exoscale/ablauf/CURRENT/api/exoscale.ablauf)
+[![Clojars Project](https://img.shields.io/clojars/v/exoscale/ablauf.svg)](https://clojars.org/exoscale/ablauf)
+
 ### Wishlist for asynchronous jobs
 
 #### An example language
@@ -122,7 +125,7 @@ AST or abstract syntax tree, is the representation of the ablauf program. It can
     * Forms: An `::ast/seq` containing the actions to be tried
     * Rescue: An `::ast/seq` containing the actions to be executed if the ast in form returns an error
     * Finally: An `::ast/seq` containing actions that will be executed after either forms or rescue completes.
-    
+
 #### Dispatcher
 An `::ast/leaf`, which represents an action performed by the program, is defined by the following spec
 
@@ -130,8 +133,8 @@ An `::ast/leaf`, which represents an action performed by the program, is defined
 (defmethod spec-by-ast-type :ast/leaf
   [_]
   (s/keys :req [:ast/action :ast/payload]))
-  
-  
+
+
 (s/def :ast/action    keyword?)
 (s/def :ast/payload   any?)
 ```
@@ -173,7 +176,7 @@ add, expanding nodes based on information provided in steps.
       (ast/log!! "should-not-run")
       (rescue!!  (ast/log!! "rescue"))
       (finally!! (ast/log!! "finally")))))
-  
+
 (let [db            (atom {})
       store         (store/mem-job-store db)
       [job context] @(runner store ast {})]
@@ -193,5 +196,3 @@ This solution has a few obvious problems:
 Storing the full AST tree, including results, for each step will limit
 the size of jobs that can be created. It does not seem however that
 we will have deep jobs.
-
-

--- a/project.clj
+++ b/project.clj
@@ -3,16 +3,11 @@
   :url "https://github.com/exoscale/ablauf"
   :license {:name "ISC License"
             :url  "https://github.com/exoscale/ablauf/tree/master/LICENSE"}
-  :codox {:source-uri "https://github.com/exoscale/ablauf/blob/{version}/{filepath}#L{line}"
-          :doc-files  ["README.md"]
-          :metadata   {:doc/format :markdown}}
-  :plugins [[lein-codox "0.10.7"]]
   :dependencies [[org.clojure/clojure "1.10.1"]
                  [spootnik/commons    "0.3.0"]
-                 [manifold            "0.1.8"]]
+                 [manifold            "0.1.9-alpha4"]]
   :deploy-repositories [["snapshots" :clojars]
                         ["releases"  :clojars]]
-  :aliases {"kaocha" ["with-profile" "+dev" "run" "-m" "kaocha.runner"]}
-  :profiles {:dev {:dependencies [[lambdaisland/kaocha "0.0-529"]]
-                   :pedantic? :ignore}}
+  :profiles {:test {:plugins [[lein-difftest "2.0.0"]
+                              [lein-cljfmt   "0.6.7"]]}}
   :pedantic? :abort)

--- a/src/ablauf/job.clj
+++ b/src/ablauf/job.clj
@@ -48,7 +48,7 @@
    a function of the output, a keyword or vector, of keyword
    pointing to a path in the output. Augments also have a destination
    a key or key vector of the position in which to augment the context."
-  [context {:ast/keys [augment] :exec/keys [result output] :as node}]
+  [context {:ast/keys [augment] :exec/keys [result output]}]
   (let [{:augment/keys [source dest]} augment
         dest-vec                      (if (sequential? dest) dest [dest])]
     (cond-> context

--- a/src/ablauf/job.clj
+++ b/src/ablauf/job.clj
@@ -114,7 +114,6 @@
           :else
           (recur (zip/next pos) nodes))))))
 
-
 (defn restart
   "Given a job, and node updates for it, figure
    out the next course of action to take.

--- a/src/ablauf/job/ast.clj
+++ b/src/ablauf/job/ast.clj
@@ -90,9 +90,6 @@
   [& forms]
   (let [[forms finally] (try-extract 'finally!! forms)
         [forms rescue]  (try-extract 'rescue!! forms)]
-    ;; The forms received here is a list of forms (not executed yet) which makes
-    ;; using `do!!`, which flatten the nodes it gets, impossible because the forms
-    ;; would be flattened. ~dajac
     {:ast/type  :ast/try
      :ast/nodes [{:ast/type  :ast/seq
                   :ast/nodes (vec forms)}

--- a/src/ablauf/job/ast.clj
+++ b/src/ablauf/job/ast.clj
@@ -59,7 +59,7 @@
 (defn do!!
   "Yields a branch of sequential actions"
   [& nodes]
-  {:ast/type :ast/seq :ast/nodes (vec (remove nil? (flatten nodes)))})
+  {:ast/type :ast/seq :ast/nodes (vec (remove nil? nodes))})
 
 (defn dopar!!
   "Yields a branch of parallel actions"

--- a/src/ablauf/job/node.clj
+++ b/src/ablauf/job/node.clj
@@ -103,10 +103,7 @@
 
 (defmethod eligible? :ast/seq
   [node]
-  (and
-    (not (some failed? (:ast/nodes node)))
-    (not (some pending? (:ast/nodes node)))
-    (some eligible? (:ast/nodes node))))
+  (some eligible? (remove done-or-pending? (:ast/nodes node))))
 
 (defmethod eligible? :ast/try
   [node]
@@ -152,6 +149,10 @@
       (and (failed? tnodes)
            (eligible? rnodes))
       (find-dispatchs rnodes)
+
+      (and (failed? tnodes)
+           (done-or-failed? rnodes))
+      (find-dispatchs fnodes)
 
       (and (not (eligible? tnodes))
            (eligible? fnodes))

--- a/src/ablauf/job/node.clj
+++ b/src/ablauf/job/node.clj
@@ -45,19 +45,19 @@
         rnodes (ast/rescue-nodes node)
         fnodes (ast/finally-nodes node)]
     (or
-      (and (failed? tnodes)
-           (done? rnodes)
-           (done? fnodes))
+     (and (failed? tnodes)
+          (done? rnodes)
+          (done? fnodes))
 
-      (and (failed? tnodes)
-           (failed? rnodes)
-           (or (done? fnodes) (failed? fnodes)))
+     (and (failed? tnodes)
+          (failed? rnodes)
+          (or (done? fnodes) (failed? fnodes)))
 
-      (and (not (failed? tnodes))
-           (done? tnodes)
-           (done? fnodes))
+     (and (not (failed? tnodes))
+          (done? tnodes)
+          (done? fnodes))
 
-      false)))
+     false)))
 
 (defmulti pending?
   "Predicate to test for pending state of a (sub)node"

--- a/src/ablauf/job/sync.clj
+++ b/src/ablauf/job/sync.clj
@@ -1,0 +1,20 @@
+(ns ablauf.job.sync
+  "
+  An execution engine for synchronous execution of ablauf jobs.
+
+  This namespace makes no assumption on how to actually
+  perform side-effects, an action runner fn must be provided.
+  "
+  (:require [ablauf.job :as job]))
+
+(defn run
+  "A basic AST runner which goes through all steps, useful to validate
+   AST execution without having to go through the manifold runner"
+  ([ast action-fn]
+   (run ast nil action-fn))
+  ([ast context action-fn]
+   (loop [[job context dispatchs]
+          (job/restart (job/make-with-context ast context) [])]
+     (if (job/done? job)
+       [job context]
+       (recur (job/restart [job context] (pmap action-fn dispatchs)))))))

--- a/test/ablauf/job/ast_test.clj
+++ b/test/ablauf/job/ast_test.clj
@@ -3,7 +3,6 @@
             [ablauf.job.ast  :refer :all]
             [clojure.test    :refer :all]))
 
-
 (deftest ast-shape
 
   (testing "Basic AST shapes"
@@ -62,7 +61,7 @@
                :exec/result :result/pending}]
              dispatchs)))
 
-    (let [dispatchs (node/find-dispatchs (try!! (finally!! (log!! :a)) ))]
+    (let [dispatchs (node/find-dispatchs (try!! (finally!! (log!! :a))))]
       (is (= [{:ast/type    :ast/leaf
                :ast/action  :action/log
                :ast/payload :a
@@ -71,11 +70,13 @@
 
 
     ;; Let's play with failures and observe behavior
+
+
     (let [base-ast
           (try!! (log!! :a) (log!! :b)
-               (rescue!! (log!! :r))
-               (finally!!
-                (log!! :f)))
+                 (rescue!! (log!! :r))
+                 (finally!!
+                  (log!! :f)))
 
           first-is-done
           (assoc-in base-ast [:ast/nodes 0 :ast/nodes 0 :exec/result] :result/success)
@@ -131,7 +132,6 @@
 
       (is (empty? (node/find-dispatchs all-done))))))
 
-
 (deftest try-shape
 
   ;; Try is a bit of a special beast since there's no guarantee
@@ -156,7 +156,6 @@
       (is (= #:ast{:type :ast/seq, :nodes []} (rescue-nodes try-ast)))
       (is (= #:ast{:type :ast/seq, :nodes []} (finally-nodes try-ast))))))
 
-
 (deftest expected-failures
 
   (let [base-ast (do!! (fail!!) (log!! :a) (log!! :b))]
@@ -175,8 +174,4 @@
          (node/find-dispatchs
           (update-in base-ast [:ast/nodes 0] assoc
                      :exec/result :result/failure
-                     :exec/output {:fail? true}))))
-
-    )
-
-  )
+                     :exec/output {:fail? true}))))))

--- a/test/ablauf/job/ast_test.clj
+++ b/test/ablauf/job/ast_test.clj
@@ -70,7 +70,7 @@
              dispatchs)))
 
 
-    ;; Le's play with failures and observe behavior
+    ;; Let's play with failures and observe behavior
     (let [base-ast
           (try!! (log!! :a) (log!! :b)
                (rescue!! (log!! :r))

--- a/test/ablauf/job/manifold_test.clj
+++ b/test/ablauf/job/manifold_test.clj
@@ -15,7 +15,6 @@
         (d/error-deferred (ex-info "Forced fail" params))
         (d/success-deferred :ok)))))
 
-
 (deftest persist-impacts-execution
   (let [action-fn (fn [{:ast/keys [action payload]}]
                     (case action

--- a/test/ablauf/job/simple_run.clj
+++ b/test/ablauf/job/simple_run.clj
@@ -31,17 +31,17 @@
 (def log-output
   [[[#:ast{:action :action/log, :id 0, :payload :a, :type :ast/leaf} nil] nil]
    [[{:ast/type :ast/leaf,
-       :ast/action :action/log,
-       :ast/payload :a,
-       :ast/id 0,
+      :ast/action :action/log,
+      :ast/payload :a,
+      :ast/id 0,
       :exec/result :result/pending}
      nil]
     {}]
    [[{:ast/type :ast/leaf,
-       :ast/action :action/log,
-       :ast/payload :a,
-       :ast/id 0,
-       :exec/result :result/success,
+      :ast/action :action/log,
+      :ast/payload :a,
+      :ast/id 0,
+      :exec/result :result/success,
       :exec/output :a
       :exec/timestamp 0
       :exec/duration 0}
@@ -51,27 +51,26 @@
 (def fail-output
   [[[#:ast{:action :action/fail, :id 0, :type :ast/leaf} nil] nil]
    [[{:ast/type :ast/leaf,
-       :ast/action :action/fail,
-       :ast/id 0,
-       :exec/result :result/pending}
+      :ast/action :action/fail,
+      :ast/id 0,
+      :exec/result :result/pending}
      nil]
     {}]
    [[{:ast/type :ast/leaf,
-       :ast/action :action/fail,
-       :ast/id 0,
-       :exec/result :result/failure,
+      :ast/action :action/fail,
+      :ast/id 0,
+      :exec/result :result/failure,
       :exec/output :error/error
       :exec/timestamp 0
-      :exec/duration 0      }
+      :exec/duration 0}
      nil]
     {}]])
-
 
 (def simple-do-output
 
   [[[#:ast{:id 0,
-            :nodes
-  [#:ast{:action :action/log,
+           :nodes
+           [#:ast{:action :action/log,
                   :id 1,
                   :payload :a,
                   :type :ast/leaf}
@@ -84,58 +83,58 @@
      nil]
     nil]
    [[#:ast{:type :ast/seq,
-         :nodes
-         [{:ast/type :ast/leaf,
-           :ast/action :action/log,
-           :ast/payload :a,
-           :ast/id 1,
-           :exec/result :result/pending}
-          #:ast{:type :ast/leaf,
-                :action :action/log,
-                :payload :b,
-                :id 2}],
-         :id 0}
-   nil]
-  {}]
- [[#:ast{:type :ast/seq,
-         :nodes
-         [{:ast/type :ast/leaf,
-           :ast/action :action/log,
-           :ast/payload :a,
-           :ast/id 1,
-           :exec/result :result/success,
-           :exec/timestamp 0,
-           :exec/duration 0,
-           :exec/output :a}
-          {:ast/type :ast/leaf,
-           :ast/action :action/log,
-           :ast/payload :b,
-           :ast/id 2,
-           :exec/result :result/pending}],
-         :id 0}
-   nil]
-  {}]
- [[#:ast{:type :ast/seq,
-         :nodes
-         [{:ast/type :ast/leaf,
-           :ast/action :action/log,
-           :ast/payload :a,
-           :ast/id 1,
-           :exec/result :result/success,
-           :exec/timestamp 0,
-           :exec/duration 0,
-           :exec/output :a}
-          {:ast/type :ast/leaf,
-           :ast/action :action/log,
-           :ast/payload :b,
-           :ast/id 2,
-           :exec/result :result/success,
-           :exec/timestamp 0,
-           :exec/duration 0,
-           :exec/output :b}],
-         :id 0}
-   nil]
-  {}]])
+           :nodes
+           [{:ast/type :ast/leaf,
+             :ast/action :action/log,
+             :ast/payload :a,
+             :ast/id 1,
+             :exec/result :result/pending}
+            #:ast{:type :ast/leaf,
+                  :action :action/log,
+                  :payload :b,
+                  :id 2}],
+           :id 0}
+     nil]
+    {}]
+   [[#:ast{:type :ast/seq,
+           :nodes
+           [{:ast/type :ast/leaf,
+             :ast/action :action/log,
+             :ast/payload :a,
+             :ast/id 1,
+             :exec/result :result/success,
+             :exec/timestamp 0,
+             :exec/duration 0,
+             :exec/output :a}
+            {:ast/type :ast/leaf,
+             :ast/action :action/log,
+             :ast/payload :b,
+             :ast/id 2,
+             :exec/result :result/pending}],
+           :id 0}
+     nil]
+    {}]
+   [[#:ast{:type :ast/seq,
+           :nodes
+           [{:ast/type :ast/leaf,
+             :ast/action :action/log,
+             :ast/payload :a,
+             :ast/id 1,
+             :exec/result :result/success,
+             :exec/timestamp 0,
+             :exec/duration 0,
+             :exec/output :a}
+            {:ast/type :ast/leaf,
+             :ast/action :action/log,
+             :ast/payload :b,
+             :ast/id 2,
+             :exec/result :result/success,
+             :exec/timestamp 0,
+             :exec/duration 0,
+             :exec/output :b}],
+           :id 0}
+     nil]
+    {}]])
 
 (def try-rescue-output
   [[#:ast{:type :ast/try,
@@ -171,7 +170,6 @@
       (is (not (job/pending? res)))
       (is (not (job/failed? res)))
       (is (= log-output output))))
-
 
   (testing "failure"
     (let [output (run-ast (ast/fail!!))
@@ -223,7 +221,6 @@
                      :three 5}}
            context))))
 
-
 (deftest runtime-test
 
   (let [runtime   {:foo 123}
@@ -273,7 +270,4 @@
                   {:action-fn action-fn})]
 
       (is (= @counter 3))
-      (reset! counter 0))
-
-
-    ))
+      (reset! counter 0))))

--- a/test/ablauf/job/simple_run.clj
+++ b/test/ablauf/job/simple_run.clj
@@ -29,7 +29,8 @@
     (vec (stream/stream->seq s))))
 
 (def log-output
-  [[[{:ast/type :ast/leaf,
+  [[[#:ast{:action :action/log, :id 0, :payload :a, :type :ast/leaf} nil] nil]
+   [[{:ast/type :ast/leaf,
        :ast/action :action/log,
        :ast/payload :a,
        :ast/id 0,
@@ -48,7 +49,8 @@
     {}]])
 
 (def fail-output
-  [[[{:ast/type :ast/leaf,
+  [[[#:ast{:action :action/fail, :id 0, :type :ast/leaf} nil] nil]
+   [[{:ast/type :ast/leaf,
        :ast/action :action/fail,
        :ast/id 0,
        :exec/result :result/pending}
@@ -67,7 +69,21 @@
 
 (def simple-do-output
 
-    [[[#:ast{:type :ast/seq,
+  [[[#:ast{:id 0,
+            :nodes
+  [#:ast{:action :action/log,
+                  :id 1,
+                  :payload :a,
+                  :type :ast/leaf}
+            #:ast{:action :action/log,
+
+                  :id 2,
+                  :payload :b,
+                  :type :ast/leaf}],
+           :type :ast/seq}
+     nil]
+    nil]
+   [[#:ast{:type :ast/seq,
          :nodes
          [{:ast/type :ast/leaf,
            :ast/action :action/log,

--- a/test/ablauf/job_test.clj
+++ b/test/ablauf/job_test.clj
@@ -1,8 +1,9 @@
 (ns ablauf.job-test
-  (:require [ablauf.job.node :as node]
-            [ablauf.job.ast  :as ast]
-            [ablauf.job      :refer :all]
-            [clojure.test    :refer :all]))
+  (:require [ablauf.job.ast  :as ast]
+            [ablauf.job.sync :as sync]
+            [ablauf.job      :refer [restart make make-with-context
+                                     ast-zip status]]
+            [clojure.test    :refer [deftest is testing]]))
 
 (deftest restart-test
 
@@ -72,3 +73,81 @@
   (is (= :job/success
          (status [{:ast/type :ast/seq, :ast/nodes [{:ast/type :ast/leaf
                                                     :exec/result :result/success}]}]))))
+
+(def finally-restart-step1
+  [[#:ast{:type :ast/try,
+        :nodes
+        [#:ast{:type :ast/seq,
+               :nodes
+               [#:ast{:type :ast/par,
+                      :nodes
+                      [{:ast/type :ast/leaf,
+                        :ast/action :record,
+                        :ast/payload :a1,
+                        :ast/id 3,
+                        :exec/result :result/pending}
+                       {:ast/type :ast/leaf,
+                        :ast/action :log,
+                        :ast/payload :a2,
+                        :ast/id 4,
+                        :exec/result :result/pending}],
+                      :id 2}
+                #:ast{:type :ast/leaf,
+                      :action :record,
+                      :payload :b1,
+                      :id 5}],
+               :id 1}
+         #:ast{:type :ast/seq,
+               :nodes
+               [#:ast{:type :ast/leaf,
+                      :action :record,
+                      :payload :r1,
+                      :id 7}],
+               :id 6}
+         #:ast{:type :ast/seq,
+               :nodes
+               [#:ast{:type :ast/leaf,
+                      :action :record,
+                      :payload :f1,
+                      :id 9}],
+               :id 8}],
+        :id 0}
+  nil]
+ nil
+ [{:ast/type :ast/leaf,
+   :ast/action :record,
+   :ast/payload :a1,
+   :ast/id 3,
+   :exec/result :result/pending}
+  {:ast/type :ast/leaf,
+   :ast/action :log,
+   :ast/payload :a2,
+   :ast/id 4,
+   :exec/result :result/pending}]])
+
+(def ast-with-finally
+  (ast/try!!
+   (ast/dopar!!
+    (ast/action!! :record :a1)
+    (ast/action!! :log :a2))
+   (ast/action!! :record :b1)
+   (rescue!! (ast/action!! :record :r1))
+   (finally!! (ast/action!! :record :f1))))
+
+(deftest ast-with-finally-sequencing-test
+  (testing "initial restart yields two concurrent actions"
+    (is (= finally-restart-step1
+           (restart (make ast-with-finally) [])))))
+
+(defn recording-action-fn
+  [state]
+  (fn [{:ast/keys [action payload] :as x}]
+    (when (= :record action)
+      (swap! state conj payload))
+    (assoc x :exec/result :result/success :exec/output {})))
+
+(deftest finally-ast-run-output
+  (let [state (atom [])
+        action-fn (recording-action-fn state)]
+    (sync/run ast-with-finally action-fn)
+    (is (= [:a1 :b1 :f1] @state))))

--- a/test/ablauf/job_test.clj
+++ b/test/ablauf/job_test.clj
@@ -76,54 +76,54 @@
 
 (def finally-restart-step1
   [[#:ast{:type :ast/try,
-        :nodes
-        [#:ast{:type :ast/seq,
-               :nodes
-               [#:ast{:type :ast/par,
-                      :nodes
-                      [{:ast/type :ast/leaf,
-                        :ast/action :record,
-                        :ast/payload :a1,
-                        :ast/id 3,
-                        :exec/result :result/pending}
-                       {:ast/type :ast/leaf,
-                        :ast/action :log,
-                        :ast/payload :a2,
-                        :ast/id 4,
-                        :exec/result :result/pending}],
-                      :id 2}
-                #:ast{:type :ast/leaf,
-                      :action :record,
-                      :payload :b1,
-                      :id 5}],
-               :id 1}
-         #:ast{:type :ast/seq,
-               :nodes
-               [#:ast{:type :ast/leaf,
-                      :action :record,
-                      :payload :r1,
-                      :id 7}],
-               :id 6}
-         #:ast{:type :ast/seq,
-               :nodes
-               [#:ast{:type :ast/leaf,
-                      :action :record,
-                      :payload :f1,
-                      :id 9}],
-               :id 8}],
-        :id 0}
-  nil]
- nil
- [{:ast/type :ast/leaf,
-   :ast/action :record,
-   :ast/payload :a1,
-   :ast/id 3,
-   :exec/result :result/pending}
-  {:ast/type :ast/leaf,
-   :ast/action :log,
-   :ast/payload :a2,
-   :ast/id 4,
-   :exec/result :result/pending}]])
+          :nodes
+          [#:ast{:type :ast/seq,
+                 :nodes
+                 [#:ast{:type :ast/par,
+                        :nodes
+                        [{:ast/type :ast/leaf,
+                          :ast/action :record,
+                          :ast/payload :a1,
+                          :ast/id 3,
+                          :exec/result :result/pending}
+                         {:ast/type :ast/leaf,
+                          :ast/action :log,
+                          :ast/payload :a2,
+                          :ast/id 4,
+                          :exec/result :result/pending}],
+                        :id 2}
+                  #:ast{:type :ast/leaf,
+                        :action :record,
+                        :payload :b1,
+                        :id 5}],
+                 :id 1}
+           #:ast{:type :ast/seq,
+                 :nodes
+                 [#:ast{:type :ast/leaf,
+                        :action :record,
+                        :payload :r1,
+                        :id 7}],
+                 :id 6}
+           #:ast{:type :ast/seq,
+                 :nodes
+                 [#:ast{:type :ast/leaf,
+                        :action :record,
+                        :payload :f1,
+                        :id 9}],
+                 :id 8}],
+          :id 0}
+    nil]
+   nil
+   [{:ast/type :ast/leaf,
+     :ast/action :record,
+     :ast/payload :a1,
+     :ast/id 3,
+     :exec/result :result/pending}
+    {:ast/type :ast/leaf,
+     :ast/action :log,
+     :ast/payload :a2,
+     :ast/id 4,
+     :exec/result :result/pending}]])
 
 (def ast-with-finally
   (ast/try!!


### PR DESCRIPTION
A few small changes to address issues that have been surfaced in the wild.
Force a first synchronous persist call ensures no job execution starts before a job record exist in the provided store.
This guarantees that consumers which yield a reference to an ID in the store can safely look up the store as soon as the ID is returned.

While there, fix an odd case where finally nodes were not called at the right point in time.

