### PR TITLE
job: store the last error in the context

### DIFF
--- a/src/ablauf/job/sync.clj
+++ b/src/ablauf/job/sync.clj
@@ -17,4 +17,6 @@
           (job/restart (job/make-with-context ast context) [])]
      (if (job/done? job)
        [job context]
-       (recur (job/restart [job context] (pmap action-fn dispatchs)))))))
+       (recur (job/restart [job context]
+                           (pmap #(action-fn (assoc % :exec/context context))
+                                 dispatchs)))))))

--- a/test/ablauf/job/error_run.clj
+++ b/test/ablauf/job/error_run.clj
@@ -1,0 +1,46 @@
+(ns ablauf.job.error-run
+  (:require [ablauf.job.ast  :as ast]
+            [ablauf.job.sync :as sync]
+            [clojure.test    :refer [deftest is]]))
+
+(def error ::error)
+
+(defn error-in-context?
+  [{:exec/keys [last-error]}]
+  (= error last-error))
+
+(def actions
+  {::fail       #(assoc % :exec/result :result/failure :exec/output error)
+   ::success    #(assoc % :exec/result :result/success :exec/output true)
+   ::find-error (fn [{:exec/keys [context] :as node}]
+                  (assoc node
+                         :exec/result :result/success
+                         :exec/output {::found (error-in-context? context)}))})
+
+(defn action-fn
+  [node]
+  (if-let [f (get actions (:ast/action node))]
+    (f node)
+    (assoc node :exec/result :result/failure :exec/output ::not-found)))
+
+(def failing-ast
+  (ast/action!! ::fail true))
+
+(deftest failing-ast-test
+  (let [[_ context] (sync/run failing-ast action-fn)]
+    (is (error-in-context? context))))
+
+(def failing-with-rescue-ast
+  (ast/try!!
+   (ast/action!! ::fail true)
+   (rescue!!
+    (ast/with-augment [::found ::found-in-rescue]
+      (ast/action!! ::find-error ::anything)))
+   (finally!!
+    (ast/with-augment [::found ::found-in-finally]
+      (ast/action!! ::find-error ::anything)))))
+
+(deftest failing-with-rescue-test
+  (let [[_ context] (sync/run failing-with-rescue-ast action-fn)]
+    (is (true? (::found-in-rescue context)))
+    (is (true? (::found-in-finally context)))))

--- a/test/ablauf/job/simple_run.clj
+++ b/test/ablauf/job/simple_run.clj
@@ -64,7 +64,7 @@
       :exec/timestamp 0
       :exec/duration 0}
      nil]
-    {}]])
+    {:exec/last-error :error/error}]])
 
 (def simple-do-output
 

--- a/test/ablauf/job_test.clj
+++ b/test/ablauf/job_test.clj
@@ -1,9 +1,9 @@
-(ns ablauf.job-test
-  (:require [ablauf.job.ast  :as ast]
-            [ablauf.job.sync :as sync]
-            [ablauf.job      :refer [restart make make-with-context
-                                     ast-zip status]]
-            [clojure.test    :refer [deftest is testing]]))
+> (ns ablauf.job-test
+    (:require [ablauf.job.ast  :as ast]
+              [ablauf.job.sync :as sync]
+              [ablauf.job      :refer [restart make make-with-context
+                                       ast-zip status]]
+              [clojure.test    :refer [deftest is testing]]))
 
 (deftest restart-test
 


### PR DESCRIPTION
This can help rescue and finally nodes act on the error that
was raised, and gives a standard location to look for in the
output